### PR TITLE
Fix typo

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,7 +27,7 @@ fi
 echo "UPSTREAM_REPO=$UPSTREAM_REPO"
 
 git clone "https://github.com/${GITHUB_REPOSITORY}.git" work
-cd work || { echo "Missing work dir" && exist 2 ; }
+cd work || { echo "Missing work dir" && exit 2 ; }
 
 git config user.name "${GITHUB_ACTOR}"
 git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"


### PR DESCRIPTION
### Fixes
- Typo for `exit`
Thanks to [piggynl](https://github.com/piggynl/sync-upstream-repo/commits?author=piggynl)
https://github.com/piggynl/sync-upstream-repo/commit/a4d2b3d4a4c794285f4886486fa1b6aa6d2454e8
- Recursively clones submodules
Thanks to @[ArudenKun](https://github.com/ArudenKun/sync-upstream-repo/commits?author=ArudenKun)
https://github.com/ArudenKun/sync-upstream-repo/commit/5df480a32cec0f9191557dd04edc425c19a090b0