### PR TITLE
fixup default DOWNSTREAM_BRANCH

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,7 +19,7 @@ fi
 if [[ -z "$DOWNSTREAM_BRANCH" ]]; then
   echo "Missing \$DOWNSTREAM_BRANCH"
   echo "Default to ${UPSTREAM_BRANCH}"
-  DOWNSTREAM_BREANCH=UPSTREAM_BRANCH
+  DOWNSTREAM_BRANCH=$UPSTREAM_BRANCH
 fi
 
 if ! echo "$UPSTREAM_REPO" | grep '\.git'; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,6 +34,7 @@ cd work || { echo "Missing work dir" && exit 2 ; }
 git config user.name "${GITHUB_ACTOR}"
 git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 git config --local user.password ${GITHUB_TOKEN}
+git config checkout.defaultRemote origin
 
 git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 


### PR DESCRIPTION
- Fixes a typo in the destination var name. Adds a missing `$` to the source var name.
- Sets `checkout.defaultRemote=origin`, so checkout may succeed when the downstream and upstream branches have the same name, such as in the default case that was fixed above.