### PR TITLE
Update entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -56,6 +56,11 @@ git push origin
 
 MERGE_RESULT=$(git merge ${MERGE_ARGS} upstream/${UPSTREAM_BRANCH})
 
+retval=$?
+if [[ "$retval" != "0" ]] ; then
+  echo "Git merge failed with return value: $retval"
+  exit $retval
+fi
 
 if [[ $MERGE_RESULT == "" ]] 
 then


### PR DESCRIPTION
Added a few lines to entrypoint.sh which should cause the action to fail if `git merge` fails.

As can be seen in the screenshot below, the action proceeds to `git push` even if the merge actually fails. In my case this caused our nightly builds to get out of sync without our knowing. Of course, if a conflict occurs in the merge, it's up to the repo maintainers to figure that out.

![auto-sync-misbehavior](https://github.com/user-attachments/assets/229cebc5-db5b-4880-834a-10837c97a4ca)
